### PR TITLE
Removed Python 3.7 from packaging action

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -13,12 +13,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
-        python-version: ["3.7", "3.8", "3.9", "3.10", "3.11"]
-        exclude:
-          - os: macos-latest
-            python-version: ["3.7"]
-          - os: windows-latest
-            python-version: ["3.7"]
+        python-version: ["3.8", "3.9", "3.10", "3.11"]
 
     steps:
       - uses: actions/checkout@v3


### PR DESCRIPTION
EOL was 2023-06-27, see https://devguide.python.org/versions/#unsupported-versions